### PR TITLE
Use custom ngrok endpoint

### DIFF
--- a/rust/net/src/env.rs
+++ b/rust/net/src/env.rs
@@ -40,17 +40,23 @@ pub(crate) const CONNECTED_ELSEWHERE_CLOSE_CODE: u16 = 4409;
 
 const DOMAIN_CONFIG_CHAT: DomainConfig = DomainConfig {
     ip_v4: &[
-        ip_addr!(v4, "76.223.92.165"),
-        ip_addr!(v4, "13.248.212.111"),
+        ip_addr!(v4, "18.140.137.220"),
+        ip_addr!(v4, "47.130.23.15"),
+        ip_addr!(v4, "175.41.148.246"),
+        ip_addr!(v4, "18.141.83.88"),
+        ip_addr!(v4, "3.0.121.23"),
     ],
     ip_v6: &[
-        ip_addr!(v6, "2600:9000:a507:ab6d:4ce3:2f58:25d7:9cbf"),
-        ip_addr!(v6, "2600:9000:a61f:527c:d5eb:a431:5239:3232"),
+        ip_addr!(v6, "2406:da18:27f:c800:2cdd:a031:6e74:8d63"),
+        ip_addr!(v6, "2406:da18:27f:c800:69c2:c02e:a3d0:45cc"),
+        ip_addr!(v6, "2406:da18:27f:c802:ec7b:9fb1:3c06:d2c"),
+        ip_addr!(v6, "2406:da18:27f:c801:ba47:de2d:9ed6:8a4c"),
+        ip_addr!(v6, "2406:da18:27f:c801:7cc8:b6cb:f6ac:364"),
     ],
     connect: ConnectionConfig {
-        hostname: "chat.signal.org",
+        hostname: "459c6bf513bb.ngrok-free.app",
         port: DEFAULT_HTTPS_PORT,
-        cert: SIGNAL_ROOT_CERTIFICATES,
+        cert: RootCertificates::Native,
         min_tls_version: Some(SslVersion::TLS1_3),
         confirmation_header_name: Some(TIMESTAMP_HEADER_NAME),
         proxy: Some(ConnectionProxyConfig {
@@ -102,9 +108,9 @@ const DOMAIN_CONFIG_CHAT_NOISE_STAGING: NoiseDomainConfig = NoiseDomainConfig {
 
 const DOMAIN_CONFIG_CDSI: DomainConfig = DomainConfig {
     connect: ConnectionConfig {
-        hostname: "cdsi.signal.org",
+        hostname: "459c6bf513bb.ngrok-free.app",
         port: DEFAULT_HTTPS_PORT,
-        cert: SIGNAL_ROOT_CERTIFICATES,
+        cert: RootCertificates::Native,
         min_tls_version: Some(SslVersion::TLS1_3),
         confirmation_header_name: None,
         proxy: Some(ConnectionProxyConfig {
@@ -112,8 +118,20 @@ const DOMAIN_CONFIG_CDSI: DomainConfig = DomainConfig {
             configs: [PROXY_CONFIG_F_PROD, PROXY_CONFIG_G],
         }),
     },
-    ip_v4: &[ip_addr!(v4, "40.122.45.194")],
-    ip_v6: &[ip_addr!(v6, "2603:1030:7::1")],
+    ip_v4: &[
+        ip_addr!(v4, "18.140.137.220"),
+        ip_addr!(v4, "47.130.23.15"),
+        ip_addr!(v4, "175.41.148.246"),
+        ip_addr!(v4, "18.141.83.88"),
+        ip_addr!(v4, "3.0.121.23"),
+    ],
+    ip_v6: &[
+        ip_addr!(v6, "2406:da18:27f:c800:2cdd:a031:6e74:8d63"),
+        ip_addr!(v6, "2406:da18:27f:c800:69c2:c02e:a3d0:45cc"),
+        ip_addr!(v6, "2406:da18:27f:c802:ec7b:9fb1:3c06:d2c"),
+        ip_addr!(v6, "2406:da18:27f:c801:ba47:de2d:9ed6:8a4c"),
+        ip_addr!(v6, "2406:da18:27f:c801:7cc8:b6cb:f6ac:364"),
+    ],
 };
 
 const DOMAIN_CONFIG_CDSI_STAGING: DomainConfig = DomainConfig {
@@ -134,9 +152,9 @@ const DOMAIN_CONFIG_CDSI_STAGING: DomainConfig = DomainConfig {
 
 const DOMAIN_CONFIG_SVR2: DomainConfig = DomainConfig {
     connect: ConnectionConfig {
-        hostname: "svr2.signal.org",
+        hostname: "459c6bf513bb.ngrok-free.app",
         port: DEFAULT_HTTPS_PORT,
-        cert: SIGNAL_ROOT_CERTIFICATES,
+        cert: RootCertificates::Native,
         min_tls_version: Some(SslVersion::TLS1_3),
         confirmation_header_name: None,
         proxy: Some(ConnectionProxyConfig {
@@ -144,8 +162,20 @@ const DOMAIN_CONFIG_SVR2: DomainConfig = DomainConfig {
             configs: [PROXY_CONFIG_F_PROD, PROXY_CONFIG_G],
         }),
     },
-    ip_v4: &[ip_addr!(v4, "20.66.40.69")],
-    ip_v6: &[],
+    ip_v4: &[
+        ip_addr!(v4, "18.140.137.220"),
+        ip_addr!(v4, "47.130.23.15"),
+        ip_addr!(v4, "175.41.148.246"),
+        ip_addr!(v4, "18.141.83.88"),
+        ip_addr!(v4, "3.0.121.23"),
+    ],
+    ip_v6: &[
+        ip_addr!(v6, "2406:da18:27f:c800:2cdd:a031:6e74:8d63"),
+        ip_addr!(v6, "2406:da18:27f:c800:69c2:c02e:a3d0:45cc"),
+        ip_addr!(v6, "2406:da18:27f:c802:ec7b:9fb1:3c06:d2c"),
+        ip_addr!(v6, "2406:da18:27f:c801:ba47:de2d:9ed6:8a4c"),
+        ip_addr!(v6, "2406:da18:27f:c801:7cc8:b6cb:f6ac:364"),
+    ],
 };
 
 const DOMAIN_CONFIG_SVR2_STAGING: DomainConfig = DomainConfig {
@@ -182,9 +212,9 @@ const DOMAIN_CONFIG_SVRB_STAGING: DomainConfig = DomainConfig {
 
 const DOMAIN_CONFIG_SVRB_PROD: DomainConfig = DomainConfig {
     connect: ConnectionConfig {
-        hostname: "svrb.signal.org",
+        hostname: "459c6bf513bb.ngrok-free.app",
         port: DEFAULT_HTTPS_PORT,
-        cert: SIGNAL_ROOT_CERTIFICATES,
+        cert: RootCertificates::Native,
         min_tls_version: Some(SslVersion::TLS1_3),
         confirmation_header_name: None,
         proxy: Some(ConnectionProxyConfig {
@@ -192,8 +222,20 @@ const DOMAIN_CONFIG_SVRB_PROD: DomainConfig = DomainConfig {
             configs: [PROXY_CONFIG_F_STAGING, PROXY_CONFIG_G],
         }),
     },
-    ip_v4: &[ip_addr!(v4, "20.114.45.6")],
-    ip_v6: &[],
+    ip_v4: &[
+        ip_addr!(v4, "18.140.137.220"),
+        ip_addr!(v4, "47.130.23.15"),
+        ip_addr!(v4, "175.41.148.246"),
+        ip_addr!(v4, "18.141.83.88"),
+        ip_addr!(v4, "3.0.121.23"),
+    ],
+    ip_v6: &[
+        ip_addr!(v6, "2406:da18:27f:c800:2cdd:a031:6e74:8d63"),
+        ip_addr!(v6, "2406:da18:27f:c800:69c2:c02e:a3d0:45cc"),
+        ip_addr!(v6, "2406:da18:27f:c802:ec7b:9fb1:3c06:d2c"),
+        ip_addr!(v6, "2406:da18:27f:c801:ba47:de2d:9ed6:8a4c"),
+        ip_addr!(v6, "2406:da18:27f:c801:7cc8:b6cb:f6ac:364"),
+    ],
 };
 
 pub const PROXY_CONFIG_F_PROD: ProxyConfig = ProxyConfig {


### PR DESCRIPTION
## Summary
- point prod network configs to `459c6bf513bb.ngrok-free.app`
- trust native system roots for those connections

## Testing
- `cargo test -p libsignal-net`

------
https://chatgpt.com/codex/tasks/task_e_68b97172b09c8327ac5bae5bf996330c